### PR TITLE
Add Delay Between Scans to Improve performance

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,17 +1,21 @@
-Version 2.0.1
+---------------------------------------------------------------------------------------------------
+Version: 2.1.0
+Date: 2023-01-16
+  Changes:
+    - added delay between area scands to improve performance
+---------------------------------------------------------------------------------------------------
+Version: 2.0.1
 Date: 2022-01-20
   Bugfixes:
     - fixed a null-pointer in add_signal
 ---------------------------------------------------------------------------------------------------
-Version 2.0.0
+Version: 2.0.0
 Date: 2022-01-20
   Changes:
     - fixed missing ghost signals
     - added migration from GhostScanner 1.6.x
     - complete rework of control.lua to improve performance
     - added settings: scan-areas-per-tick, which can drastically increase performance, but reduces time inbetween updates of each scanner
----------------------------------------------------------------------------------------------------
-V previous code/versions by Optera V
 ---------------------------------------------------------------------------------------------------
 Version: 1.6.5
 Date: 2022-07-22

--- a/control.lua
+++ b/control.lua
@@ -35,6 +35,8 @@ local Scanner_Name = "ghost-scanner"
 -- MOD SETTINGS --
 local sapt = settings.global["ghost-scanner-scan-areas-per-tick"].value
 local UpdateInterval = settings.global["ghost-scanner-update-interval"].value
+--How long to wait between scanning sapt number of areas
+local ScanAreaDelay = settings.global["ghost-scanner-area-scan-delay"].value
 local MaxResults = settings.global["ghost-scanner-max-results"].value
 if MaxResults == 0 then MaxResults = nil end
 local ShowHidden = settings.global["ghost-scanner-show-hidden"].value
@@ -140,6 +142,8 @@ do -- tick handlers
 
 
   function OnTick(event)
+
+    if not event.tick % ScanAreaDelay == 0 then return end
     --log("number of ScanAreas "..tostring(#global.ScanAreas))
     --log("updateindex: "..tostring(global.UpdateIndex))
     --log("number of Scanners "..tostring(#global.GhostScanners))

--- a/control.lua
+++ b/control.lua
@@ -143,7 +143,7 @@ do -- tick handlers
 
   function OnTick(event)
 
-    if not event.tick % ScanAreaDelay == 0 then return end
+    if not (event.tick % ScanAreaDelay == 0) then return end
     --log("number of ScanAreas "..tostring(#global.ScanAreas))
     --log("updateindex: "..tostring(global.UpdateIndex))
     --log("number of Scanners "..tostring(#global.GhostScanners))

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "GhostScanner2",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "title": "Ghost Scanner2",
   "author": "Tiavor",
   "contact": "",

--- a/settings.lua
+++ b/settings.lua
@@ -19,6 +19,15 @@ data:extend({
   },
   {
     type = "int-setting",
+    name = "ghost-scanner-area-scan-delay",
+    order = "aba",
+    setting_type = "runtime-global",
+    default_value = 5,
+    minimum_value = 1,
+    maximum_value = 216000, -- 1h
+  },
+  {
+    type = "int-setting",
     name = "ghost-scanner-max-results",
     order = "ac",
     setting_type = "runtime-global",


### PR DESCRIPTION
Ghost Scanner 2 still has massive UPS impact even if only 1 area per tick is scanned, to improve this I've added a delay so scans only happens every n ticks (5 by default can be changed in settings). This improves performance somewhat, at the cost of long delays for updating.
Of course the better solution would be to use events.